### PR TITLE
Ajout check_process

### DIFF
--- a/check_process
+++ b/check_process
@@ -1,0 +1,21 @@
+;; Test complet
+	auto_remove=1
+	; Manifest
+		is_public="Yes"	(PUBLIC|public=Yes|private=No)
+	; Checks
+		pkg_linter=1
+		setup_sub_dir=0
+		setup_root=0
+		setup_nourl=1
+		setup_private=0
+		setup_public=0
+		upgrade=1
+		backup_restore=1
+		multi_instance=0
+		wrong_user=0
+		wrong_path=0
+		incorrect_path=0
+		corrupt_source=0
+		fail_download_source=0
+		port_already_use=0
+		final_path_already_use=0


### PR DESCRIPTION
Ajout du fichier check_process pour l'intégration continue.
Le package ne peut pas être testé correctement sans ce fichier.